### PR TITLE
feat: implement conversation history formatting and update chat handling

### DIFF
--- a/src/main/java/com/sparta/financialadvisorchatbot/service/ConversationFormatter.java
+++ b/src/main/java/com/sparta/financialadvisorchatbot/service/ConversationFormatter.java
@@ -1,0 +1,24 @@
+package com.sparta.financialadvisorchatbot.service;
+
+import com.sparta.financialadvisorchatbot.entities.ConversationHistory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ConversationFormatter {
+    public String formatConversation(List<ConversationHistory> conversationHistory) {
+        StringBuilder formattedConversation = new StringBuilder();
+
+        for (ConversationHistory entry : conversationHistory) {
+            String userInput = entry.getInput();
+            String botResponse = entry.getResponse();
+
+            formattedConversation.append("User: ").append(userInput).append("\n");
+            formattedConversation.append("Bot: ").append(botResponse).append("\n");
+        }
+
+        return formattedConversation.toString();
+    }
+
+}

--- a/src/main/java/com/sparta/financialadvisorchatbot/service/ConversationService.java
+++ b/src/main/java/com/sparta/financialadvisorchatbot/service/ConversationService.java
@@ -59,9 +59,9 @@ public class ConversationService {
 
     public List<ConversationHistory> getConversationHistory(Integer conversationId) {
         List<ConversationHistory> conversationHistory = conversationHistoryRepository.findByConversation_Id(conversationId);
-        if (conversationHistory.isEmpty()) {
-            throw new IllegalArgumentException("No conversation history found for this ID.");
-        }
+//        if (conversationHistory.isEmpty()) {
+//            throw new IllegalArgumentException("No conversation history found for this ID.");
+//        }
         return conversationHistory;
     }
 
@@ -76,7 +76,7 @@ public class ConversationService {
         }
         return null;
     }
-    public String generateGptResponse(String userInput) {
-        return openAiService.getResponse(userInput);
+    public String generateGptResponse(String userInput, List<ConversationHistory> messageHistory, Integer currentConversationId) {
+        return openAiService.getResponse(userInput, messageHistory, currentConversationId);
     }
 }

--- a/src/main/java/com/sparta/financialadvisorchatbot/service/OpenAiService.java
+++ b/src/main/java/com/sparta/financialadvisorchatbot/service/OpenAiService.java
@@ -1,5 +1,6 @@
 package com.sparta.financialadvisorchatbot.service;
 
+import com.sparta.financialadvisorchatbot.entities.ConversationHistory;
 import com.sparta.financialadvisorchatbot.models.OpenAiRequest;
 import com.sparta.financialadvisorchatbot.models.OpenAiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,7 @@ import java.util.List;
 @Service
 public class OpenAiService {
     private final RestTemplate restTemplate;
+    private final ConversationFormatter conversationFormatter;
 
     @Value("${openai.api.key}")
     private String apiKey;
@@ -25,21 +27,24 @@ public class OpenAiService {
     private String prompt;
 
     @Autowired
-    public OpenAiService(RestTemplate restTemplate) {
+    public OpenAiService(RestTemplate restTemplate, ConversationFormatter conversationFormatter) {
         this.restTemplate = restTemplate;
+        this.conversationFormatter = conversationFormatter;
     }
 
-    public String getResponse(String userInput) {
+    public String getResponse(String userInput, List<ConversationHistory> messageHistory, Integer conversationId) {
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Content-Type", "application/json");
         headers.set("api-key", apiKey);
 
-        OpenAiRequest body = new OpenAiRequest();
+        String input = conversationFormatter.formatConversation(messageHistory) + "\nUser: " + userInput;
 
+        OpenAiRequest body = new OpenAiRequest();
+        //todo: send the conversation history with the prompt
         List<OpenAiRequest.Message> messages = new ArrayList<>();
         messages.add(new OpenAiRequest.Message("system", prompt));
-        messages.add(new OpenAiRequest.Message("user", userInput));
+        messages.add(new OpenAiRequest.Message("user", input));
 
         body.setMessages(messages);
 


### PR DESCRIPTION
- Added ConversationFormatter to format conversation history to send with the user input to ai.
- Modified BasicWebController to utilize ConversationFormatter for generating bot responses.
- Updated ConversationService to support passing conversation history to OpenAiService.
- Enhanced OpenAiService to include formatted conversation history in API requests.
- Removed exception for empty conversation history; now returns an empty list instead.

OpenAiService 'getResponse' will now take the conversation history as a string, formatted by ConversationFormatter class, to allow a better conversational flow when interacting with the ai, allowing memory of conversation even from faq bot responses.

ConversationFormatter is just a utility class, but I couldn't get the bean to wire correctly. For now I have put it inside the service layer and given the @Service annotation to allow it work. This can and will change.