### PR TITLE
Fix: Conversation History search functionality

### DIFF
--- a/src/main/java/com/sparta/financialadvisorchatbot/controllers/DataAnalysisController.java
+++ b/src/main/java/com/sparta/financialadvisorchatbot/controllers/DataAnalysisController.java
@@ -6,6 +6,8 @@ import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -13,7 +15,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,27 +37,41 @@ public class DataAnalysisController {
     public String getAllConversations(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size, @RequestParam(defaultValue = "") String keyword, Model model){
 
         ResponseEntity<List<ConversationId>> allConversations;
-        if(keyword.isEmpty()) {
-            allConversations =
-                    webClient
-                            .get()
-                            .uri("/api/sg-financial-chatbot/v1.0/conversations?page=" + page + "&size=" + size)
-                            .retrieve()
-                            .toEntityList(ConversationId.class)
-                            .block();
+        boolean isSearch;
+        try {
+            if (keyword.isEmpty()) {
+                allConversations =
+                        webClient
+                                .get()
+                                .uri("/api/sg-financial-chatbot/v1.0/conversations?page=" + page + "&size=" + size)
+                                .retrieve()
+                                .onStatus(HttpStatusCode::is4xxClientError, ClientResponse::createException)
+                                .toEntityList(ConversationId.class)
+                                .block();
+                isSearch = false;
+            } else {
+                allConversations = webClient
+                        .get()
+                        .uri("/api/sg-financial-chatbot/v1.0/conversations/containing?keyword=" + keyword + "&page=" + page + "&size=" + size)
+                        .retrieve()
+                        .onStatus(HttpStatusCode::is4xxClientError, ClientResponse::createException)
+                        .toEntityList(ConversationId.class)
+                        .block();
+                isSearch = true;
+            }
         }
-        else{
-            allConversations = webClient
-                    .get()
-                    .uri("/api/sg-financial-chatbot/v1.0/conversations/containing?keyword=" + keyword + "&page=" + page + "&size=" + size)
-                    .retrieve()
-                    .toEntityList(ConversationId.class)
-                    .block();
+        catch (WebClientResponseException e) {
+            model.addAttribute("conversations", new ArrayList<ConversationId>());
+            model.addAttribute("error", keyword);
+            model.addAttribute("currentPage", page);
+            model.addAttribute("currentYear", java.time.Year.now().getValue());
+            return "conversations";
         }
 
         model.addAttribute("conversations", allConversations.getBody());
         model.addAttribute("currentPage", page);
         model.addAttribute("currentYear", java.time.Year.now().getValue());
+        model.addAttribute("isSearch", isSearch);
         return "conversations";
 
     }

--- a/src/main/java/com/sparta/financialadvisorchatbot/controllers/DataAnalysisController.java
+++ b/src/main/java/com/sparta/financialadvisorchatbot/controllers/DataAnalysisController.java
@@ -70,6 +70,7 @@ public class DataAnalysisController {
 
         model.addAttribute("conversations", allConversations.getBody());
         model.addAttribute("currentPage", page);
+        model.addAttribute("keyword", keyword);
         model.addAttribute("currentYear", java.time.Year.now().getValue());
         model.addAttribute("isSearch", isSearch);
         return "conversations";

--- a/src/main/java/com/sparta/financialadvisorchatbot/controllers/DataAnalysisController.java
+++ b/src/main/java/com/sparta/financialadvisorchatbot/controllers/DataAnalysisController.java
@@ -30,34 +30,32 @@ public class DataAnalysisController {
     }
 
     @GetMapping("/history")
-    public String getAllConversations(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size, Model model){
-        ResponseEntity<List<ConversationId>> allConversations =
-                webClient
-                        .get()
-                        .uri("/api/sg-financial-chatbot/v1.0/conversations?page=" + page + "&size=" + size)
-                        .retrieve()
-                        .toEntityList(ConversationId.class)
-                        .block();
+    public String getAllConversations(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size, @RequestParam(defaultValue = "") String keyword, Model model){
+
+        ResponseEntity<List<ConversationId>> allConversations;
+        if(keyword.isEmpty()) {
+            allConversations =
+                    webClient
+                            .get()
+                            .uri("/api/sg-financial-chatbot/v1.0/conversations?page=" + page + "&size=" + size)
+                            .retrieve()
+                            .toEntityList(ConversationId.class)
+                            .block();
+        }
+        else{
+            allConversations = webClient
+                    .get()
+                    .uri("/api/sg-financial-chatbot/v1.0/conversations/containing?keyword=" + keyword + "&page=" + page + "&size=" + size)
+                    .retrieve()
+                    .toEntityList(ConversationId.class)
+                    .block();
+        }
 
         model.addAttribute("conversations", allConversations.getBody());
         model.addAttribute("currentPage", page);
         model.addAttribute("currentYear", java.time.Year.now().getValue());
         return "conversations";
-    }
-    @GetMapping("history/conversations/containing")
-    public String getSearchedConversations(@RequestParam String keyword, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size, Model model){
-        ResponseEntity<List<ConversationId>> allConversations =
-                webClient
-                        .get()
-                        .uri("/api/sg-financial-chatbot/v1.0//conversations/containing?keyword=" +keyword+ "&page="+ page + "&size=" + size)
-                        .retrieve()
-                        .toEntityList(ConversationId.class)
-                        .block();
 
-        model.addAttribute("conversations", allConversations.getBody());
-        model.addAttribute("currentPage", page);
-        model.addAttribute("currentYear", java.time.Year.now().getValue());
-        return "conversations";
     }
 
     @GetMapping("/conversations/{id}")

--- a/src/main/resources/static/css/adminStyles.css
+++ b/src/main/resources/static/css/adminStyles.css
@@ -88,16 +88,16 @@ tbody tr:nth-child(even) {
 
 .search-container input {
     flex-grow: 1 !important;
-    border-radius: 50px !important;
-    padding: 10px 20px !important; /* Add extra padding for a bubble effect */
+    border-radius: 25px !important;
+    padding: 12px 20px !important; /* Add extra padding for a bubble effect */
     background-color: #f0f0f0 !important; /* Light gray background for the bubble look */
     border: none !important;
     color: #333 !important; /* Darker text color for better readability */
-    width: calc(100% - 120px) !important; /* Adjust width based on the container */
+    width: calc(100% - 150px) !important; /* Adjust width based on the container */
     margin-right: 10px !important;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1) !important; /* Subtle shadow for a raised effect */
     font-size: 16px !important;
-    height: 19px !important; /* Set height to match button height */
+    height: 20px !important; /* Set height to match button height */
     line-height: 20px !important; /* Adjust line-height to vertically center the text */
 }
 
@@ -106,19 +106,20 @@ tbody tr:nth-child(even) {
 }
 
 .search-container button {
-    border-radius: 50px !important;
+    border-radius: 25px !important;
     background-color: #ff0066 !important;
     border: none !important;
     color: white !important;
-    padding: 10px 20px !important; /* Keep padding consistent */
+    padding: 12px 20px !important; /* Keep padding consistent */
     margin-left: 10px !important;
+    margin-bottom: 7px;
     cursor: pointer !important;
     display: flex !important;
     align-items: center !important;
     justify-content: center !important;
     font-size: 16px !important;
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1) !important; /* Same shadow effect for consistency */
-    height: 40px !important; /* Set height to ensure consistency */
+    height: 47px !important; /* Set height to ensure consistency */
 }
 
 .search-container button:hover {

--- a/src/main/resources/static/css/adminStyles.css
+++ b/src/main/resources/static/css/adminStyles.css
@@ -129,3 +129,28 @@ tbody tr:nth-child(even) {
 .search-container button i {
     margin-right: 5px !important;
 }
+
+.card-custom {
+    background-color: #2b2b2b; /* Match background color */
+    color: white;
+    border: 1px solid #444; /* Border color similar to table headers */
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); /* Slight shadow for elevated effect */
+    padding: 20px; /* Padding inside the card */
+    max-width: 600px; /* Width of the card */
+    margin: 0 auto; /* Center horizontally */
+}
+
+.card-custom .btn-sparta {
+    margin-top: 20px; /* Spacing above the button */
+    display: block; /* Center the button */
+    width: 100px; /* Consistent button width */
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.center-align-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/src/main/resources/templates/conversation-details.html
+++ b/src/main/resources/templates/conversation-details.html
@@ -30,7 +30,7 @@
     </table>
 
     <div class="row center-align">
-        <a th:href="@{/admin/history}" class="btn-sparta">Back</a>
+        <a onclick="history.back()" class="btn-sparta">Back</a>
     </div>
 </div>
 

--- a/src/main/resources/templates/conversations.html
+++ b/src/main/resources/templates/conversations.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <div class="header">
-    Financial Chatbot Central
+    Sparta Finance Chatbot Admin
 </div>
 
 <div class="container">
@@ -21,7 +21,8 @@
 
 
     <!-- Conversation History Table -->
-    <table class="table table-dark table-hover text-center">
+
+    <table th:if="${not conversations.isEmpty()}" class="table table-dark table-hover text-center">
         <thead>
         <tr>
             <th>Conversation ID</th>
@@ -37,6 +38,23 @@
         </tr>
         </tbody>
     </table>
+    <div class="header" th:if="${conversations.isEmpty()}">
+        <div class="text-center display-4">
+            No conversations with user input of '<span th:text="${error}"></span>' found.
+        </div>
+        <form th:action="@{history}" method="get" class="container ma-4">
+            <button type="submit" class="btn-sparta">
+                 Back
+            </button>
+        </form>
+    </div>
+    <div th:if="${isSearch==true}" class="text-center display-4">
+        <form th:action="@{history}" method="get" class="container ma-4">
+            <button type="submit" class="btn-sparta">
+                Back to all conversations
+            </button>
+        </form>
+    </div>
 </div>
 
 <div class="row center-align mt-3">
@@ -46,7 +64,6 @@
 <div class="row center-align">
     <span th:text="'Page ' + (${currentPage} + 1)"></span>
 </div>
-
 
 <!--<footer class="footer">-->
 <!--    <p>&copy; <span th:text="${currentYear}">2024</span> Sparta Global. All rights reserved.</p>-->

--- a/src/main/resources/templates/conversations.html
+++ b/src/main/resources/templates/conversations.html
@@ -12,9 +12,9 @@
 </div>
 
 <div class="container">
-    <form th:action="@{history/conversations/containing}" method="get" class="search-container mt-4">
+    <form th:action="@{history}" method="get" class="search-container mt-4">
         <input type="text" id="searchInput" name="keyword" placeholder="Search conversations..." required class="search-input">
-        <button type="submit" class="search-button" >
+        <button type="submit" class="search-button mt-4" >
             <i class="bi bi-search"></i> Search
         </button>
     </form>
@@ -32,17 +32,19 @@
         <tbody>
         <tr th:each="conversation : ${conversations}" th:if="${not #lists.isEmpty(conversation.getConversationHistories())}">
             <td th:text="${conversation.getId()}">1</td>
-            <td th:text="${conversation.getConversationHistories[0].getId().getCreatedAt()}">2024-09-27T14:30:00</td>
+            <td th:text="${conversation.getConversationHistories[0].getId().getCreatedAt().toString().replace('T', ' ')}">2024-09-27T14:30:00</td>
             <td><a th:href="@{'/admin/conversations/' + ${conversation.getId()}}" class="btn-sparta">View</a></td>
         </tr>
         </tbody>
     </table>
 </div>
 
-<div class="row center-align">
+<div class="row center-align mt-3">
     <button th:if="${currentPage > 0}" th:onclick="'location.href=\'/admin/history?page=' + (${currentPage} - 1) + '&size=10\''" class="btn-sparta">Previous</button>
-    <span th:text="'Page ' + (${currentPage} + 1)"></span>
     <button th:if="${conversations.size() >= 10}" th:onclick="'location.href=\'/admin/history?page=' + (${currentPage} + 1) + '&size=10\''" class="btn-sparta">Next</button>
+</div>
+<div class="row center-align">
+    <span th:text="'Page ' + (${currentPage} + 1)"></span>
 </div>
 
 

--- a/src/main/resources/templates/conversations.html
+++ b/src/main/resources/templates/conversations.html
@@ -12,14 +12,21 @@
 </div>
 
 <div class="container">
+
     <form th:action="@{history}" method="get" class="search-container mt-4">
         <input type="text" id="searchInput" name="keyword" placeholder="Search conversations..." required class="search-input">
+        <input type="hidden" name="page" th:value="0" />
+        <input type="hidden" name="size" value="10" />
         <button type="submit" class="search-button mt-4" >
             <i class="bi bi-search"></i> Search
         </button>
     </form>
 
-
+<div th:if="${isSearch == true}" class="row center-align mt-5">
+    <div>
+        <b>Search query:</b> '<span th:text="${keyword}"></span>'
+    </div>
+</div>
     <!-- Conversation History Table -->
 
     <table th:if="${not conversations.isEmpty()}" class="table table-dark table-hover text-center">
@@ -38,18 +45,23 @@
         </tr>
         </tbody>
     </table>
-    <div class="header" th:if="${conversations.isEmpty()}">
-        <div class="text-center display-4">
-            No conversations with user input of '<span th:text="${error}"></span>' found.
+
+    <div th:if="${conversations.isEmpty()}" class="center-align-container">
+        <div class="card-custom text-center">
+            <h4 class="card-title">No Conversations Found</h4>
+            <p class="card-text">
+                No conversations with user input of '<span th:text="${error}"></span>' found.
+            </p>
+            <form th:action="@{history}" method="get">
+                <button type="submit" class="btn-sparta">
+                    Back
+                </button>
+            </form>
         </div>
-        <form th:action="@{history}" method="get" class="container ma-4">
-            <button type="submit" class="btn-sparta">
-                 Back
-            </button>
-        </form>
     </div>
-    <div th:if="${isSearch==true}" class="text-center display-4">
-        <form th:action="@{history}" method="get" class="container ma-4">
+
+    <div th:if="${isSearch == true}" class="row center-align mt-5">
+        <form th:action="@{history}" method="get" class="mt-4">
             <button type="submit" class="btn-sparta">
                 Back to all conversations
             </button>
@@ -58,8 +70,22 @@
 </div>
 
 <div class="row center-align mt-3">
-    <button th:if="${currentPage > 0}" th:onclick="'location.href=\'/admin/history?page=' + (${currentPage} - 1) + '&size=10\''" class="btn-sparta">Previous</button>
-    <button th:if="${conversations.size() >= 10}" th:onclick="'location.href=\'/admin/history?page=' + (${currentPage} + 1) + '&size=10\''" class="btn-sparta">Next</button>
+    <span th:if="${isSearch == true}">
+        <button th:if="${currentPage > 0}"
+                th:attr="onclick=|location.href='/admin/history?keyword=' + '${keyword}' + '&page=' + (${currentPage} - 1) + '&size=10'|"
+                class="btn-sparta">Previous</button>
+        <button th:if="${conversations.size() >= 5}"
+                th:attr="onclick=|location.href='/admin/history?keyword=' + '${keyword}' + '&page=' + (${currentPage} + 1) + '&size=10'|"
+                class="btn-sparta">Next</button>
+    </span>
+    <span th:if="${isSearch == false}">
+        <button th:if="${currentPage > 0}"
+                th:onclick="'location.href=\'/admin/history?page=' + (${currentPage} - 1) + '&size=10\''"
+                class="btn-sparta">Previous</button>
+        <button th:if="${conversations.size() >= 10}"
+                th:onclick="'location.href=\'/admin/history?page=' + (${currentPage} + 1) + '&size=10\''"
+                class="btn-sparta">Next</button>
+    </span>
 </div>
 <div class="row center-align">
     <span th:text="'Page ' + (${currentPage} + 1)"></span>

--- a/src/main/resources/templates/conversations.html
+++ b/src/main/resources/templates/conversations.html
@@ -39,6 +39,12 @@
     </table>
 </div>
 
+<div class="row center-align">
+    <button th:if="${currentPage > 0}" th:onclick="'location.href=\'/admin/history?page=' + (${currentPage} - 1) + '&size=10\''" class="btn-sparta">Previous</button>
+    <span th:text="'Page ' + (${currentPage} + 1)"></span>
+    <button th:if="${conversations.size() >= 10}" th:onclick="'location.href=\'/admin/history?page=' + (${currentPage} + 1) + '&size=10\''" class="btn-sparta">Next</button>
+</div>
+
 
 <!--<footer class="footer">-->
 <!--    <p>&copy; <span th:text="${currentYear}">2024</span> Sparta Global. All rights reserved.</p>-->


### PR DESCRIPTION
### Overview
Fixed conversation history search functionality when attempting to search twice in a row. 

 - Fixed pagination when using search feature
 - Changed the way conversation detail page handles going back to history to place user back on the previous page using history.back()
 - fixed error caused by 404 exception coming from API call leading page to display white screen error when no conversation id's were found